### PR TITLE
fix: replace hard-coded datasource in test Q3.4-Opt

### DIFF
--- a/Apache_Druid/Druid_SSB_testplan.jmx
+++ b/Apache_Druid/Druid_SSB_testplan.jmx
@@ -985,7 +985,7 @@
             <collectionProp name="Arguments.arguments">
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{&quot;query&quot;: &quot;select c_city, s_city, d_year, sum(lo_revenue) as lo_revenue from ssb_data where (c_city=&apos;UNITED KI1&apos; or c_city=&apos;UNITED KI5&apos;) and (s_city=&apos;UNITED KI1&apos; or s_city=&apos;UNITED KI5&apos;) and TIME_FLOOR(\&quot;__time\&quot;,&apos;P1M&apos;) = TIME_PARSE(&apos;Dec1997&apos;,&apos;MMMyyyy&apos;) group by c_city, s_city, d_year order by d_year asc, lo_revenue desc&quot;,	&quot;context&quot;: {&#xd;
+                <stringProp name="Argument.value">{&quot;query&quot;: &quot;select c_city, s_city, d_year, sum(lo_revenue) as lo_revenue from ${jmDataSource} where (c_city=&apos;UNITED KI1&apos; or c_city=&apos;UNITED KI5&apos;) and (s_city=&apos;UNITED KI1&apos; or s_city=&apos;UNITED KI5&apos;) and TIME_FLOOR(\&quot;__time\&quot;,&apos;P1M&apos;) = TIME_PARSE(&apos;Dec1997&apos;,&apos;MMMyyyy&apos;) group by c_city, s_city, d_year order by d_year asc, lo_revenue desc&quot;,	&quot;context&quot;: {&#xd;
 	&quot;sqlQueryId&quot;: &quot;${jmRunTitle}-Q3.4-${jmQueryGroup}-${jmFeatureFlags}&quot;,&#xd;
 		&quot;useApproximateCountDistinct&quot;: ${jmUseApproximateCountDistinct},&#xd;
        	&quot;useApproximateTopN&quot;: ${jmUseApproximateTopN},&#xd;


### PR DESCRIPTION
All samplers other than Q3.4-Opt are configured to use the variable `${jmDataSource}`
Q3.4-Opt is hard-coded to use the name `ssb_data`
If any other name is used for the datasource (e.g., `ssb_data_small`, to test a small version of the dataset), this sampler will fail:
![image](https://github.com/implydata/benchmark-tools/assets/7910938/353332e9-5b07-48f1-88c3-95ab61a174d8)

With the response Body of:
```
{"error":"Plan validation failed","errorMessage":"org.apache.calcite.runtime.CalciteContextException: From line 1, column 67 to line 1, column 74: Object 'ssb_data' not found","errorClass":"org.apache.calcite.tools.ValidationException","host":null}```